### PR TITLE
Add Express server skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+MONGO_URI=mongodb://localhost:27017/dbname
+SESSION_SECRET=yourSecret
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ $ npm start
 # build for production with minification
 $ npm run build
 ```
+## Express Server
+
+Run `npm run server` to start the Express backend. The server reads environment variables from a `.env` file and connects to MongoDB before listening on the configured port.
+
 
 ## What's included
 

--- a/config/db.js
+++ b/config/db.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose')
+
+const connectDB = async () => {
+  try {
+    await mongoose.connect(process.env.MONGO_URI)
+    console.log('MongoDB connected')
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}
+
+module.exports = connectDB

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "release-version": "node build/change-version.mjs",
     "serve": "serve dist",
     "start": "npm-run-all --sequential clean css js sync --parallel localhost watch",
+    "server": "node server.js",
     "sync": "npm-run-all --parallel sync-*",
     "sync-assets": "syncdir src/assets dist/assets",
     "sync-views": "syncdir src/views dist",
@@ -86,7 +87,14 @@
     "@coreui/icons": "^3.0.1",
     "@coreui/utils": "^2.0.2",
     "chart.js": "^4.4.7",
-    "simplebar": "^6.3.0"
+    "simplebar": "^6.3.0",
+    "csurf": "^1.11.0",
+    "dotenv": "^16.4.5",
+    "ejs": "^3.1.9",
+    "express": "^5.0.0",
+    "express-session": "^2.0.0",
+    "connect-mongo": "^5.0.4",
+    "mongoose": "^8.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.26.4",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,53 @@
+const path = require('path')
+const express = require('express')
+const session = require('express-session')
+const MongoStore = require('connect-mongo')
+const csrf = require('csurf')
+const dotenv = require('dotenv')
+
+const connectDB = require('./config/db')
+
+dotenv.config()
+
+const app = express()
+
+// Connect to MongoDB
+connectDB()
+
+// JSON parsing and URL-encoded form parsing
+app.use(express.json())
+app.use(express.urlencoded({ extended: false }))
+
+// Static files
+app.use(express.static(path.join(__dirname, 'public')))
+
+// Sessions stored in MongoDB
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'secret',
+    resave: false,
+    saveUninitialized: false,
+    store: MongoStore.create({ mongoUrl: process.env.MONGO_URI })
+  })
+)
+
+// CSRF protection
+app.use(csrf())
+
+// View engine setup
+app.set('view engine', 'ejs')
+app.set('views', path.join(__dirname, 'views'))
+
+// Sample root route
+app.get('/', (req, res) => {
+  res.send('Express server running')
+})
+
+// 404 handler
+app.use((req, res) => {
+  res.status(404)
+  res.render('404')
+})
+
+const PORT = process.env.PORT || 3000
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`))

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Page Not Found</title>
+</head>
+<body>
+  <h1>404 - Page Not Found</h1>
+  <p>The page you are looking for does not exist.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an Express 5 server wired to MongoDB
- wire up MongoDB helper
- serve 404 page with ejs
- document how to start the Express backend

## Testing
- `npm run js-lint` *(fails: Cannot find package 'eslint-config-xo')*

------
https://chatgpt.com/codex/tasks/task_e_68431d586e28832dae5926f8b92178bf