### PR TITLE
Add session middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "@coreui/icons": "^3.0.1",
     "@coreui/utils": "^2.0.2",
     "chart.js": "^4.4.7",
+    "connect-mongo": "^4.6.0",
+    "express-session": "^1.17.3",
     "simplebar": "^6.3.0"
   },
   "devDependencies": {

--- a/server/sessionMiddleware.mjs
+++ b/server/sessionMiddleware.mjs
@@ -1,0 +1,20 @@
+import session from 'express-session'
+import mongoStoreFactory from 'connect-mongo'
+
+export default function sessionMiddleware() {
+  const MongoStore = mongoStoreFactory.create
+
+  return session({
+    secret: process.env.SESSION_SECRET ?? 'change_this_secret',
+    resave: false,
+    saveUninitialized: false,
+    store: MongoStore({
+      mongoUrl: process.env.MONGODB_URI ?? 'mongodb://127.0.0.1/session'
+    }),
+    cookie: {
+      maxAge: 24 * 60 * 60 * 1000,
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production'
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- add dependencies for express-session and connect-mongo
- implement session middleware

## Testing
- `npm run js-lint` *(fails: cannot find module 'eslint-config-xo')*

------
https://chatgpt.com/codex/tasks/task_e_68431d6125a8832d9884cdf4a2f92d11