### PR TITLE
Implement warm theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ $ npm start
 # build for production with minification
 $ npm run build
 ```
+
+### Warm color theme
+
+The default light theme uses warm beige tones. Customize the colors by editing
+`src/scss/style.scss` and rebuilding the assets.
 ## Express Server
 
 Run `npm run server` to start the Express backend. The server reads environment variables from a `.env` file and connects to MongoDB before listening on the configured port.

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -3,6 +3,15 @@
 );
 @use "vendors/simplebar";
 
+:root,
+[data-coreui-theme="light"] {
+  --cui-body-bg: #f5e6d0;
+  --cui-body-color: #5b4636;
+  --cui-primary: #d77f2a;
+  --cui-secondary: #c26d27;
+  --cui-tertiary-bg: #f8f1e9;
+}
+
 body {
   background-color: var(--cui-tertiary-bg);
 }

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -31,9 +31,9 @@
     <link rel="icon" type="image/png" sizes="96x96" href="assets/favicon/favicon-96x96.png">
     <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon/favicon-16x16.png">
     <link rel="manifest" href="assets/favicon/manifest.json">
-    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileColor" content="#f5e6d0">
     <meta name="msapplication-TileImage" content="assets/favicon/ms-icon-144x144.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#f5e6d0">
     <!-- Vendors styles-->
     <link rel="stylesheet" href="node_modules/simplebar/dist/simplebar.css">
     <link rel="stylesheet" href="css/vendors/simplebar.css">


### PR DESCRIPTION
## Summary
- add a warm beige color palette in style.scss
- apply warm background color to HTML meta theme-color
- document how to customize the warm theme

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843d18855e4832d8816924b91673b6a