### PR TITLE
Add neon theme and UI polish

### DIFF
--- a/src/assets/icons/theme.svg
+++ b/src/assets/icons/theme.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <symbol id="theme-sun" viewBox="0 0 16 16">
+    <circle cx="8" cy="8" r="3" fill="currentColor"/>
+    <g stroke="currentColor" stroke-width="1" stroke-linecap="round">
+      <line x1="8" y1="1" x2="8" y2="3"/>
+      <line x1="8" y1="13" x2="8" y2="15"/>
+      <line x1="1" y1="8" x2="3" y2="8"/>
+      <line x1="13" y1="8" x2="15" y2="8"/>
+      <line x1="2.5" y1="2.5" x2="3.5" y2="3.5"/>
+      <line x1="12.5" y1="12.5" x2="13.5" y2="13.5"/>
+      <line x1="12.5" y1="3.5" x2="13.5" y2="2.5"/>
+      <line x1="2.5" y1="13.5" x2="3.5" y2="12.5"/>
+    </g>
+  </symbol>
+  <symbol id="theme-moon" viewBox="0 0 16 16">
+    <path d="M11 9a5 5 0 1 1-4-7 6 6 0 1 0 4 7z" fill="currentColor"/>
+  </symbol>
+  <symbol id="theme-auto" viewBox="0 0 16 16">
+    <path d="M8 0a8 8 0 0 0 0 16V0z" fill="currentColor"/>
+    <path d="M8 0a8 8 0 0 1 0 16V0z" fill="currentColor" opacity=".5"/>
+  </symbol>
+</svg>

--- a/src/js/color-modes.js
+++ b/src/js/color-modes.js
@@ -21,6 +21,8 @@
   }
 
   const setTheme = theme => {
+    document.documentElement.classList.add('theme-transition')
+    window.setTimeout(() => document.documentElement.classList.remove('theme-transition'), 500)
     if (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
       document.documentElement.setAttribute('data-coreui-theme', 'dark')
     } else {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -15,6 +15,11 @@ Chart.defaults.plugins.tooltip.position = 'nearest'
 Chart.defaults.plugins.tooltip.external = coreui.ChartJS.customTooltips
 Chart.defaults.defaultFontColor = coreui.Utils.getStyle('--cui-body-color')
 
+// zoom plugin
+if (window.ChartZoom) {
+  Chart.register(window.ChartZoom)
+}
+
 document.documentElement.addEventListener('ColorSchemeChange', () => {
   cardChart1.data.datasets[0].pointBackgroundColor = coreui.Utils.getStyle('--cui-primary')
   cardChart2.data.datasets[0].pointBackgroundColor = coreui.Utils.getStyle('--cui-info')
@@ -50,6 +55,14 @@ const cardChart1 = new Chart(document.getElementById('card-chart1'), {
     plugins: {
       legend: {
         display: false
+      }
+      ,
+      zoom: {
+        zoom: {
+          wheel: { enabled: true },
+          pinch: { enabled: true },
+          mode: 'xy'
+        }
       }
     },
     maintainAspectRatio: false,

--- a/src/pug/_partials/head.pug
+++ b/src/pug/_partials/head.pug
@@ -24,6 +24,11 @@ meta(name='msapplication-TileColor', content='#ffffff')
 meta(name='msapplication-TileImage', content='assets/favicon/ms-icon-144x144.png')
 meta(name='theme-color', content='#ffffff')
 
+// Futuristic font
+link(rel='preconnect', href='https://fonts.googleapis.com')
+link(rel='preconnect', href='https://fonts.gstatic.com', crossorigin='')
+link(href='https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap', rel='stylesheet')
+
 // Vendors styles
 link(rel='stylesheet' href='node_modules/simplebar/dist/simplebar.css')
 link(rel='stylesheet' href='css/vendors/simplebar.css')

--- a/src/pug/_partials/header.pug
+++ b/src/pug/_partials/header.pug
@@ -29,22 +29,22 @@ header.header.header-sticky.p-0.mb-4
       li.nav-item.dropdown
         button.btn.btn-link.nav-link.py-2.px-2.d-flex.align-items-center(type="button" aria-expanded="false" data-coreui-toggle="dropdown")
           svg.icon.icon-lg.theme-icon-active
-            use(xlink:href="node_modules/@coreui/icons/sprites/free.svg#cil-contrast")
+            use(xlink:href="assets/icons/theme.svg#theme-auto")
         ul.dropdown-menu.dropdown-menu-end(style='--cui-dropdown-min-width: 8rem;')
           li
             button.dropdown-item.d-flex.align-items-center(type='button' data-coreui-theme-value='light')
               svg.icon.icon-lg.me-3
-                use(xlink:href="node_modules/@coreui/icons/sprites/free.svg#cil-sun")
+                use(xlink:href="assets/icons/theme.svg#theme-sun")
               | Light
           li
             button.dropdown-item.d-flex.align-items-center(type='button' data-coreui-theme-value='dark')
               svg.icon.icon-lg.me-3
-                use(xlink:href="node_modules/@coreui/icons/sprites/free.svg#cil-moon")
+                use(xlink:href="assets/icons/theme.svg#theme-moon")
               | Dark
           li
             button.dropdown-item.d-flex.align-items-center.active(type='button' data-coreui-theme-value='auto')
               svg.icon.icon-lg.me-3
-                use(xlink:href="node_modules/@coreui/icons/sprites/free.svg#cil-contrast")
+                use(xlink:href="assets/icons/theme.svg#theme-auto")
               | Auto
       li.nav-item.py-1
         .vr.h-100.mx-2.text-body.text-opacity-75

--- a/src/pug/views/index.pug
+++ b/src/pug/views/index.pug
@@ -7,6 +7,7 @@ block scripts
   if !starter
     // Plugins and scripts required by this view
     script(src='node_modules/chart.js/dist/chart.umd.js')
+    script(src='node_modules/chartjs-plugin-zoom/dist/chartjs-plugin-zoom.js')
     script(src='node_modules/@coreui/chartjs/dist/js/coreui-chartjs.js')
     script(src='node_modules/@coreui/utils/dist/umd/index.js')
     script(src='js/main.js')
@@ -135,27 +136,27 @@ block view
           .text-body-secondary Visits
           .fw-semibold.text-truncate 29.703 Users (40%)
           .progress.progress-thin.mt-2
-            .progress-bar.bg-success(role='progressbar', style='width: 40%', aria-valuenow='40', aria-valuemin='0', aria-valuemax='100')
+            .progress-bar(role='progressbar', style='width: 40%; background-image: linear-gradient(90deg, var(--cui-neon-primary), var(--cui-neon-secondary))', aria-valuenow='40', aria-valuemin='0', aria-valuemax='100')
         .col
           .text-body-secondary Unique
           .fw-semibold.text-truncate 24.093 Users (20%)
           .progress.progress-thin.mt-2
-            .progress-bar.bg-info(role='progressbar', style='width: 20%', aria-valuenow='20', aria-valuemin='0', aria-valuemax='100')
+            .progress-bar(role='progressbar', style='width: 20%; background-image: linear-gradient(90deg, var(--cui-neon-secondary), var(--cui-neon-primary))', aria-valuenow='20', aria-valuemin='0', aria-valuemax='100')
         .col
           .text-body-secondary Pageviews
           .fw-semibold.text-truncate 78.706 Views (60%)
           .progress.progress-thin.mt-2
-            .progress-bar.bg-warning(role='progressbar', style='width: 60%', aria-valuenow='60', aria-valuemin='0', aria-valuemax='100')
+            .progress-bar(role='progressbar', style='width: 60%; background-image: linear-gradient(90deg, var(--cui-neon-primary), #00ffff)', aria-valuenow='60', aria-valuemin='0', aria-valuemax='100')
         .col
           .text-body-secondary New Users
           .fw-semibold.text-truncate 22.123 Users (80%)
           .progress.progress-thin.mt-2
-            .progress-bar.bg-danger(role='progressbar', style='width: 80%', aria-valuenow='80', aria-valuemin='0', aria-valuemax='100')
+            .progress-bar(role='progressbar', style='width: 80%; background-image: linear-gradient(90deg, var(--cui-neon-secondary), #ff8c00)', aria-valuenow='80', aria-valuemin='0', aria-valuemax='100')
         .col.d-none.d-xl-block
           .text-body-secondary Bounce Rate
           .fw-semibold.text-truncate 40.15%
           .progress.progress-thin.mt-2
-            .progress-bar(role='progressbar', style='width: 40%', aria-valuenow='40', aria-valuemin='0', aria-valuemax='100')
+            .progress-bar(role='progressbar', style='width: 40%; background-image: linear-gradient(90deg, #00ffff, var(--cui-neon-primary))', aria-valuenow='40', aria-valuemin='0', aria-valuemax='100')
   // /.card
   .row.g-4.mb-4
     .col-sm-6.col-lg-4

--- a/src/pug/views/login.pug
+++ b/src/pug/views/login.pug
@@ -1,7 +1,18 @@
 extends ../_layout/pages.pug
 
+block styles
+  style.
+    .login-page::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: url('assets/img/full.jpg') center/cover no-repeat fixed;
+      filter: brightness(.4);
+      z-index: -1;
+    }
+
 block view
-  .container
+  .login-page.container.d-flex.align-items-center.justify-content-center.min-vh-100
     .row.justify-content-center
       .col-lg-8
         .card-group.d-block.d-md-flex.row

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -10,10 +10,38 @@
   --cui-primary: #d77f2a;
   --cui-secondary: #c26d27;
   --cui-tertiary-bg: #f8f1e9;
+  // neon palette
+  --cui-neon-primary: #39ff14;
+  --cui-neon-secondary: #f531ff;
+  --cui-body-bg-gradient: linear-gradient(135deg, #0f0c29 0%, #302b63 50%, #24243e 100%);
 }
 
 body {
-  background-color: var(--cui-tertiary-bg);
+  background: var(--cui-body-bg-gradient);
+  font-family: 'Orbitron', sans-serif;
+}
+
+.theme-transition {
+  transition: background-color .5s ease, color .5s ease;
+}
+
+.card {
+  @include transition(transform .3s, box-shadow .3s);
+
+  &:hover,
+  &:focus-within {
+    transform: translateY(-0.25rem);
+    box-shadow: 0 0 1rem var(--cui-neon-primary);
+  }
+}
+
+.btn {
+  @include transition(background-color .3s, box-shadow .3s);
+
+  &:hover,
+  &:focus {
+    box-shadow: 0 0 0.5rem var(--cui-neon-secondary);
+  }
 }
 
 .wrapper {


### PR DESCRIPTION
## Summary
- introduce neon palette variables and gradient body background
- add hover micro-interactions for cards and buttons
- embed futuristic font
- replace theme toggle icons with custom SVG sprite
- animate theme switching
- load chart.js zoom plugin and enable it
- use gradient progress bars and video style login background

## Testing
- `npm run js-lint` *(fails: Cannot find package 'eslint-config-xo')*
- `npm run css-lint` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d2daa408832daa38e6a912bc53ed